### PR TITLE
Modificação do UcConsts_Language.pas

### DIFF
--- a/source/UcConsts_Language.pas
+++ b/source/UcConsts_Language.pas
@@ -1,4 +1,6 @@
 unit UcConsts_Language;
+ 
+ {$codepage UTF8} //Converte o código para UTF8 
 
 {$IFDEF FPC}
   {$MODE Delphi}


### PR DESCRIPTION
Inserido o código de conversão para a linguagem normal de String por padrão.

Quando executava o demo o Lazarus não entendia uma razão Português, por isso inseri um literal {$ codepage UTF8} para o compilador de sentido que o código é UTF8.